### PR TITLE
Fix bugs when $EDITOR="emacs -nw"

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -79,9 +79,9 @@ ext x?html?, has w3m,             terminal = w3m "$@"
 # Misc
 #-------------------------------------------
 # Define the "editor" for text files as first action
-mime ^text,  label editor = $EDITOR "$@"
+mime ^text,  label editor = "$EDITOR" -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = $EDITOR "$@"
+!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = "$EDITOR" -- "$@"
 !mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
@@ -184,5 +184,5 @@ label wallpaper, number 14, mime ^image, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = ask
-label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = $EDITOR "$@"
+label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$EDITOR" -- "$@"
 label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$PAGER" -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -79,9 +79,9 @@ ext x?html?, has w3m,             terminal = w3m "$@"
 # Misc
 #-------------------------------------------
 # Define the "editor" for text files as first action
-mime ^text,  label editor = "$EDITOR" -- "$@"
+mime ^text,  label editor = $EDITOR "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = "$EDITOR" -- "$@"
+!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = $EDITOR "$@"
 !mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
@@ -184,5 +184,5 @@ label wallpaper, number 14, mime ^image, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = ask
-label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$EDITOR" -- "$@"
+label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = $EDITOR "$@"
 label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$PAGER" -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -79,9 +79,9 @@ ext x?html?, has w3m,             terminal = w3m "$@"
 # Misc
 #-------------------------------------------
 # Define the "editor" for text files as first action
-mime ^text,  label editor = "$EDITOR" -- "$@"
+mime ^text,  label editor = $EDITOR -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = "$EDITOR" -- "$@"
+!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = $EDITOR -- "$@"
 !mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
@@ -184,5 +184,5 @@ label wallpaper, number 14, mime ^image, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = ask
-label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$EDITOR" -- "$@"
+label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = $EDITOR -- "$@"
 label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$PAGER" -- "$@"


### PR DESCRIPTION
This patch fixes 2 problems at once in the default config, which prevent one
from editing files when his $EDITOR variable is set to "emacs -nw":
- $EDITOR variables consisting of "program name + options" are not handled
  correctly because of quotes around $EDITOR. As a result, if $EDITOR is not
  a simple program name (i.e. if it includes options, as in "emacs -nw"), the
  full string is taken as a program and fails to run.
  Error message: (/bin/sh: 1: emacs -nw: not found)
  Removing quotes fixes this problem.
- emacs does not seems to handle the "--" correctly: it does not open any file
  when it is there. I don't know why it is there, but removing it does not
  prevent other editors (vim, nano) to run correctly, and makes emacs work.