### PR TITLE
Add a 'cycle' option to direction

### DIFF
--- a/ranger/ext/direction.py
+++ b/ranger/ext/direction.py
@@ -81,6 +81,9 @@ class Direction(dict):
     def percentage(self):
         return 'percentage' in self and self['percentage']
 
+    def cycle(self):
+        return self.get('cycle')
+
     def multiply(self, n):
         for key in ('up', 'right', 'down', 'left'):
             try:
@@ -126,6 +129,8 @@ class Direction(dict):
                 pos += maximum
         else:
             pos += current
+        if self.cycle():
+            return minimum + pos % (maximum + offset - minimum)
         return int(max(min(pos, maximum + offset - 1), minimum))
 
     def select(self, lst, current, pagesize, override=None, offset=1):


### PR DESCRIPTION
This allows to loop on a file list, going at the other side of the list when trying to go beyond the boundaries (e.g. pressing down when the last file is selected). 

Test command: `move up=1 cycle=true`

Note: in `minimum + pos % (maximum + offset - minimum)`, I am not sure if the use of 'offset' is appropriate (i.e. not sure whether it is broken or not).