### PR TITLE
Priority change

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -135,11 +135,11 @@ mime ^video, terminal, !X, has mplayer   = mplayer -- "$@"
 #-------------------------------------------
 # Image Viewing:
 #-------------------------------------------
-mime ^image, has eog,    X, flag f = eog -- "$@"
-mime ^image, has eom,    X, flag f = eom -- "$@"
 mime ^image, has sxiv,   X, flag f = sxiv -- "$@"
 mime ^image, has feh,    X, flag f = feh -- "$@"
 mime ^image, has mirage, X, flag f = mirage -- "$@"
+mime ^image, has eog,    X, flag f = eog -- "$@"
+mime ^image, has eom,    X, flag f = eom -- "$@"
 mime ^image, has gimp,   X, flag f = gimp -- "$@"
 ext xcf,                 X, flag f = gimp -- "$@"
 


### PR DESCRIPTION
I think if someone has sxiv, feh or mirage installed, it should have a higher priority than eog or eom, because they are normally automatically installed along with mate or gnome.

it fits the philosophy of browser or documents default priority.