### PR TITLE
Fix renaming with insufficient privileges

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -715,10 +715,10 @@ class rename(Command):
         if access(new_name, os.F_OK):
             return self.fm.notify("Can't rename: file already exists!", bad=True)
 
-        self.fm.rename(self.fm.thisfile, new_name)
-        f = File(new_name)
-        self.fm.thisdir.pointed_obj = f
-        self.fm.thisfile = f
+        if self.fm.rename(self.fm.thisfile, new_name):
+            f = File(new_name)
+            self.fm.thisdir.pointed_obj = f
+            self.fm.thisfile = f
 
     def tab(self):
         return self._tab_directory_content()

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1302,3 +1302,5 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
             os.renames(src, dest)
         except OSError as err:
             self.notify(err)
+            return False
+        return True


### PR DESCRIPTION
Closes #97
When renaming a file, the internal file pointer will be set to the new
file name without checking if the file actually got renamed. This would
cause the file pointer to be set to an invalid file if renaming failed
because of bad privileges. With no valid file, the previev window will
disappear. This patch adds a return value to the core renaming method so
it can be checking by the caller. The rename command now checks if the
rename succeeded and only then sets the new file pointer.