### PR TITLE
Deleting a file with a cached image preview no longer crashes ranger

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -879,7 +879,7 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
         pager = self.ui.get_pager()
         path = file.realpath
 
-        if not path:
+        if not path or not os.path.exists(path):
             return None
 
         if self.settings.preview_images and file.image:


### PR DESCRIPTION
If user deletes a file with an associated cached image preview (via scope.sh), ranger used to check this now non-existent file's modification time and crash in the process. I've added a check whether a file still exists.