### PR TITLE
Fixed the file macros with :flat enabled

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -793,14 +793,12 @@ class bulkrename(Command):
     def execute(self):
         import sys
         import tempfile
-        from os.path import relpath
         from ranger.container.file import File
         from ranger.ext.shell_escape import shell_escape as esc
         py3 = sys.version_info[0] >= 3
 
         # Create and edit the file list
-        filenames = [relpath(f.path, start=self.fm.thisdir.path)
-                     for f in self.fm.thistab.get_selection()]
+        filenames = [f.relative_path for f in self.fm.thistab.get_selection()]
         listfile = tempfile.NamedTemporaryFile(delete=False)
         listpath = listfile.name
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -20,7 +20,7 @@ from ranger.container.settings import LocalSettings
 
 def sort_by_basename(path):
     """returns path.basename (for sorting)"""
-    return path.drawn_basename
+    return path.relative_path
 
 def sort_by_basename_icase(path):
     """returns case-insensitive path.basename (for sorting)"""

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -94,11 +94,11 @@ class FileSystemObject(FileManagerAware, SettingsAware):
         self.basename_is_rel_to = basename_is_rel_to
         if basename_is_rel_to == None:
             self.basename = basename(path)
-            self.drawn_basename = self.basename
+            self.relative_path = self.basename
         else:
             self.basename = basename(path)
-            self.drawn_basename = relpath(path, basename_is_rel_to)
-        self.basename_lower = self.drawn_basename.lower()
+            self.relative_path = relpath(path, basename_is_rel_to)
+        self.basename_lower = self.relative_path.lower()
         self.extension = splitext(self.basename)[1].lstrip(extsep) or None
         self.dirname = dirname(path)
         self.preload = preload
@@ -142,7 +142,7 @@ class FileSystemObject(FileManagerAware, SettingsAware):
     @lazy_property
     def basename_natural(self):
         return [c if i % 3 == 1 else (int(c) if c else 0) for i, c in \
-            enumerate(_extract_number_re.split(self.drawn_basename))]
+            enumerate(_extract_number_re.split(self.relative_path))]
 
     @lazy_property
     def basename_natural_lower(self):

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -258,12 +258,12 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
         macros['rangerdir'] = ranger.RANGERDIR
 
         if self.fm.thisfile:
-            macros['f'] = self.fm.thisfile.basename
+            macros['f'] = self.fm.thisfile.relative_path
         else:
             macros['f'] = MACRO_FAIL
 
         if self.fm.thistab.get_selection:
-            macros['s'] = [fl.basename for fl in self.fm.thistab.get_selection()]
+            macros['s'] = [fl.relative_path for fl in self.fm.thistab.get_selection()]
         else:
             macros['s'] = MACRO_FAIL
 
@@ -273,7 +273,7 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
             macros['c'] = MACRO_FAIL
 
         if self.fm.thisdir.files:
-            macros['t'] = [fl.basename for fl in self.fm.thisdir.files
+            macros['t'] = [fl.relative_path for fl in self.fm.thisdir.files
                     if fl.realpath in (self.fm.tags or [])]
         else:
             macros['t'] = MACRO_FAIL

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -277,10 +277,10 @@ class BrowserColumn(Pager):
                 else:
                     text = metadata.title
             if use_linemode == "filename":
-                text = drawn.drawn_basename
+                text = drawn.relative_path
             elif use_linemode == "permissions":
                 text = "%s %s %s %s" % (drawn.get_permission_string(),
-                        drawn.user, drawn.group, drawn.drawn_basename)
+                        drawn.user, drawn.group, drawn.relative_path)
 
 
             if drawn.marked and (self.main_column or \

--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -117,7 +117,7 @@ class TitleBar(Widget):
 
         if self.fm.thisfile is not None and \
                 self.settings.show_selection_in_titlebar:
-            bar.add(self.fm.thisfile.drawn_basename, 'file')
+            bar.add(self.fm.thisfile.relative_path, 'file')
 
     def _get_right_part(self, bar):
         # TODO: fix that pressed keys are cut off when chaining CTRL keys


### PR DESCRIPTION
The `%f`, `%s` and `%t` file macros used to return only the file basename, even if it was not located in the current directory. It would break the `%d/%f` idiom and many others when `:flat` was enabled. Now they return a path relative to the current directory (which is the same as the basename when `:flat` is disabled).

Additionally, I've renamed the fsobject.drawn_basename to fsobject.relative_path according to the discussion on the #ranger IRC channel and used it wherever possible.