### PR TITLE
updated comment to reflect current default value for confirm_on_delete

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -29,7 +29,7 @@ set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$
 set show_hidden false
 
 # Ask for a confirmation when running the "delete" command?
-# Valid values are "always" (default), "never", "multiple"
+# Valid values are "always", "never", "multiple" (default)
 # With "multiple", ranger will ask only if you delete multiple files at once.
 set confirm_on_delete multiple
 


### PR DESCRIPTION
Fixed comment concerning default value of confirm_on_delete in rc.conf.

Issue #260 