### PR TITLE
added tab complete functionality for :set colorschemes

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -344,12 +344,20 @@ class set_(Command):
             return (self.firstpart + setting for setting in settings \
                     if setting.startswith(name))
         if not value:
+            # Cycle through colorschemes when name, but no value is specified
+            if name == "colorscheme":
+                return (self.firstpart + colorscheme
+                    for colorscheme in self.fm.thisfile.colorscheme_dict.keys())
             return self.firstpart + str(settings[name])
         if bool in settings.types_of(name):
             if 'true'.startswith(value.lower()):
                 return self.firstpart + 'True'
             if 'false'.startswith(value.lower()):
                 return self.firstpart + 'False'
+        # Tab complete colorscheme values if incomplete value is present
+        if name == "colorscheme":
+            return (self.firstpart + colorscheme for colorscheme in self.fm.thisfile.colorscheme_dict.keys() \
+                    if colorscheme.startswith(value))
 
 
 class setlocal(set_):

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -14,8 +14,8 @@ BAD_INFO = '?'
 
 import re
 from grp import getgrgid
-from os import lstat, stat, getcwd
-from os.path import abspath, basename, dirname, realpath, splitext, extsep, relpath
+from os import lstat, stat, getcwd, listdir
+from os.path import abspath, basename, dirname, realpath, splitext, extsep, relpath, expanduser, isdir
 from pwd import getpwuid
 from ranger.core.linemode import *
 from ranger.core.shared import FileManagerAware, SettingsAware
@@ -23,6 +23,7 @@ from ranger.ext.shell_escape import shell_escape
 from ranger.ext.spawn import spawn
 from ranger.ext.lazy_property import lazy_property
 from ranger.ext.human_readable import human_readable
+from ranger import RANGERDIR,CONFDIR
 
 if hasattr(str, 'maketrans'):
     maketrans = str.maketrans
@@ -87,6 +88,21 @@ class FileSystemObject(FileManagerAware, SettingsAware):
     linemode_dict = dict(
         (linemode.name, linemode()) for linemode in
         [DefaultLinemode, TitleLinemode, PermissionsLinemode]
+    )
+
+    _colorscheme = "default"
+    colorschemes = []
+    # Load colorscheme names from main ranger/colorschemes dir
+    for item in listdir(RANGERDIR + '/colorschemes'):
+        if not item.startswith('__'):
+            colorschemes.append(item.rsplit('.', 1)[0])
+    # Load colorscheme names from ~/.config/ranger/colorschemes if dir exists
+    if isdir(expanduser(CONFDIR + '/colorschemes')):
+        for item in listdir(expanduser(CONFDIR + '/colorschemes')):
+            if not item.startswith('__'):
+                colorschemes.append(item.rsplit('.', 1)[0])
+    colorscheme_dict = dict(
+        (colorscheme, colorscheme + '.py') for colorscheme in colorschemes
     )
 
     def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):


### PR DESCRIPTION
Added tab complete functionality for colorschemes under the :set command.

Will cycle through all availble colorschemes (under ranger/colorschemes) when no colorscheme is specified; and will tab complete if an incomplete colorscheme name is specified

Fixes #244 