### PR TITLE
os module does not have "mkdirs" function 

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1244,7 +1244,7 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
 
     def mkdir(self, name):
         try:
-            os.mkdirs(os.path.join(self.thisdir.path, name))
+            os.makedirs(os.path.join(self.thisdir.path, name))
         except OSError as err:
             self.notify(err)
 


### PR DESCRIPTION
# error message

```
'module' object has no attribute 'mkdirs'
```

# refs

https://docs.python.org/2/library/os.html?highlight=makedirs#os.makedirs
https://docs.python.org/3/library/os.html?highlight=makedirs#os.makedirs

ranger is best file manager! Thanks.

