### PR TITLE
core.tab: added the after_chdir_hook

### DIFF
--- a/ranger/api/__init__.py
+++ b/ranger/api/__init__.py
@@ -34,3 +34,19 @@ def register_linemode(*linemodes):
     from ranger.container.fsobject import FileSystemObject
     for linemode in linemodes:
         FileSystemObject.linemode_dict[linemode.name] = linemode()
+
+def chdir_hook(fun):
+    """A decorator used to register a chdir hook.
+
+    Two arguments will be passed to the hook: the previous cwd and the
+    new cwd. If the hook returns True, the rest of the hooks will not
+    be run.
+
+    The hooks are called already from the new cwd.
+
+    This decorator appends the new hook at the end of the hook list.
+
+    """
+    from ranger.core.tab import Tab
+    Tab.after_chdir_hooks.append(fun)
+    return fun

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -10,6 +10,8 @@ from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.ext.signals import SignalDispatcher
 
 class Tab(FileManagerAware, SettingsAware):
+    after_chdir_hooks = []
+
     def __init__(self, path):
         self.thisdir = None  # Current Working Directory
         self._thisfile = None  # Current File
@@ -125,6 +127,11 @@ class Tab(FileManagerAware, SettingsAware):
         self.thisdir = new_thisdir
 
         self.thisdir.load_content_if_outdated()
+
+        if previous and path:
+            for hook in self.after_chdir_hooks:
+                if hook(previous.path, path):
+                    break
 
         # build the pathway, a tuple of directory objects which lie
         # on the path to the current directory.


### PR DESCRIPTION
The added `after_chdir_hook` is called after changing the current ranger directory. The details are described in the docstring of the `api.chdir_hook` decorator.

I've got a feeling that I might have used the ranger signals as the `Tab.enter_dir` function calls `self.fm.signal_emit` but I've noticed it only after I've already finished. Additionally the signals seem like they are not meant to be used by the user, unlike the new solution.