### PR TITLE
the register_linemode function reimplemented as a decorator

### DIFF
--- a/ranger/api/__init__.py
+++ b/ranger/api/__init__.py
@@ -29,8 +29,7 @@ def hook_ready(fm):
 
 from ranger.core.linemode import LinemodeBase
 
-def register_linemode(*linemodes):
-    """Register the linemodes in a dictionary of the available linemodes."""
+def custom_linemode(linemode_class):
     from ranger.container.fsobject import FileSystemObject
-    for linemode in linemodes:
-        FileSystemObject.linemode_dict[linemode.name] = linemode()
+    FileSystemObject.linemode_dict[linemode_class.name] = linemode_class()
+    return linemode_class

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -29,9 +29,17 @@ class LinemodeBase(object):
         """The left-aligned part of the line."""
         raise NotImplementedError
 
-    @abstractmethod
     def infostring(self, file, metadata):
-        """The right-aligned part of the line."""
+        """The right-aligned part of the line.
+
+        If `NotImplementedError' is raised (e.g. this method is just
+        not implemented in the actual linemode), the caller should
+        provide its own implementation, which in this case means
+        displaying the hardlink count of the directories. Useful
+        because only the caller (BrowserColumn) possesses the data
+        necessary to display that information.
+
+        """
         raise NotImplementedError
 
 
@@ -40,10 +48,6 @@ class DefaultLinemode(LinemodeBase):
 
     def filetitle(self, file, metadata):
         return file.relative_path
-
-    def infostring(self, file, metadata):
-        # Should never be called for this linemode, implemented in BrowserColumn
-        raise NotImplementedError
 
 
 class TitleLinemode(LinemodeBase):

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -301,13 +301,13 @@ class BrowserColumn(Pager):
             # info string
             infostring = []
             infostringlen = 0
-            if current_linemode.name == "filename":
-                infostring = self._draw_infostring_display(drawn, space)
-            else:
+            try:
                 infostringdata = current_linemode.infostring(drawn, metadata)
                 if infostringdata:
                     infostring.append([" " + infostringdata + " ",
                                        ["infostring"]])
+            except NotImplementedError:
+                infostring = self._draw_infostring_display(drawn, space)
             if infostring:
                 infostringlen = self._total_len(infostring)
                 if space - infostringlen > 2:


### PR DESCRIPTION
While I was working on #275, it occurred to me that the `register_linemode` function could be replaced with a bit more elegant decorator. In my opinion using it would be much more natural from the user's point of view.