### PR TITLE
Fix a typo s/self\.notify/self\.fm\.notify/

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1439,7 +1439,7 @@ class linemode(default_linemode):
             mode = DEFAULT_LINEMODE
 
         if mode not in self.fm.thisfile.linemode_dict:
-            self.notify("Unhandled linemode: `%s'" % mode, bad=True)
+            self.fm.notify("Unhandled linemode: `%s'" % mode, bad=True)
             return
 
         self.fm.thisdir._set_linemode_of_children(mode)


### PR DESCRIPTION
s/self\.notify/self\.fm\.notify/