### PR TITLE
ranger.py: fixed issues with $tempfile in embedded shell

### DIFF
--- a/ranger.py
+++ b/ranger.py
@@ -9,7 +9,7 @@
 # default is simply "ranger". (Not this file itself!)
 # The other arguments are passed to ranger.
 """":
-tempfile='/tmp/chosendir'
+tempfile="$(mktemp)"
 ranger="${1:-ranger}"
 test -z "$1" || shift
 "$ranger" --choosedir="$tempfile" "${@:-$(pwd)}"
@@ -17,8 +17,8 @@ returnvalue=$?
 test -f "$tempfile" &&
 if [ "$(cat -- "$tempfile")" != "$(echo -n `pwd`)" ]; then
     cd "$(cat "$tempfile")"
-    rm -f -- "$tempfile"
 fi
+rm -f -- "$tempfile"
 return $returnvalue
 """ and None
 


### PR DESCRIPTION
Previously, $tempfile (namely, /tmp/chosendir) was not cleaned up correctly when the ranger process quit in `pwd` without moving to other directory.  This causes permission errors in multi-user environments trying to overwrite $tempfile created by a different user.

This commit solves the problem in two ways:
 - Correctly clean up temporary files
 - Avoid writing to the same temporary by using mktemp(1)