### PR TITLE
bugfix: prevent deletion of important extra spaces

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -241,13 +241,13 @@ map S shell $SHELL
 
 map :  console
 map ;  console
-map !  console shell 
+map !  eval fm.open_console('shell ')
 map @  console -p6 shell  %%s
-map #  console shell -p 
-map s  console shell 
-map r  chain draw_possible_programs; console open_with 
-map f  console find 
-map cd console cd 
+map #  eval fm.open_console('shell -p ')
+map s  eval fm.open_console('shell ')
+map r  chain draw_possible_programs; eval fm.open_console('open_with ')
+map f  eval fm.open_console('find ')
+map cd eval fm.open_console('cd ')
 
 # Change the line mode
 map Mf linemode filename
@@ -270,7 +270,7 @@ map <F3> display_file
 map <F4> edit
 map <F5> copy
 map <F6> cut
-map <F7> console mkdir 
+map <F7> eval fm.open_console('mkdir ')
 map <F8> console delete
 map <F10> exit
 
@@ -285,7 +285,7 @@ map <PAGEDOWN> move down=1   pages=True
 map <PAGEUP>   move up=1     pages=True
 map <CR>       move right=1
 #map <DELETE>   console delete
-map <INSERT>   console touch 
+map <INSERT>   eval fm.open_console('touch ')
 
 # VIM-like
 copymap <UP>       k
@@ -336,7 +336,7 @@ map yn shell -f echo -n %f    | xsel -i; xsel -o | xsel -i -b
 # Filesystem Operations
 map =  chmod
 
-map cw console rename 
+map cw eval fm.open_console('rename ')
 map a  rename_append
 map A  eval fm.open_console('rename ' + fm.thisfile.basename)
 map I  eval fm.open_console('rename ' + fm.thisfile.basename, position=7)
@@ -371,7 +371,7 @@ map yj  eval fm.copy(dirarg=dict(down=1), narg=quantifier)
 map yk  eval fm.copy(dirarg=dict(up=1), narg=quantifier)
 
 # Searching
-map /  console search 
+map /  eval fm.open_console('search ')
 map n  search_next
 map N  search_next forward=False
 map ct search_next order=tag
@@ -438,7 +438,7 @@ map zP    toggle_option preview_directories
 map zs    toggle_option sort_case_insensitive
 map zu    toggle_option autoupdate_cumulative_size
 map zv    toggle_option use_preview_script
-map zf    console filter 
+map zf    eval fm.open_console('filter ')
 
 # Bookmarks
 map `<any>  enter_bookmark %any


### PR DESCRIPTION
This fixes a bug in those editors which automatically delete extra spaces at the end of lines; without the fix when (after editing rc.conf) i.e. pressing r to open files we need to manually add a space between "open_with" and the command