### PR TITLE
Merge command

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -343,6 +343,7 @@ map A  eval fm.open_console('rename ' + fm.thisfile.basename)
 map I  eval fm.open_console('rename ' + fm.thisfile.basename, position=7)
 
 map pp paste
+map pm paste merge=True
 map po paste overwrite=True
 map pl paste_symlink relative=False
 map pL paste_symlink relative=True

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1223,9 +1223,9 @@ class Actions(FileManagerAware, SettingsAware):
                 link(source_path,
                     next_available_filename(target_path))
 
-    def paste(self, overwrite=False):
+    def paste(self, overwrite=False, merge=False):
         """Paste the selected items into the current directory"""
-        self.loader.add(CopyLoader(self.copy_buffer, self.do_cut, overwrite))
+        self.loader.add(CopyLoader(self.copy_buffer, self.do_cut, overwrite, merge))
         self.do_cut = False
 
     def delete(self):

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -42,12 +42,13 @@ class Loadable(object):
 
 class CopyLoader(Loadable, FileManagerAware):
     progressbar_supported = True
-    def __init__(self, copy_buffer, do_cut=False, overwrite=False):
+    def __init__(self, copy_buffer, do_cut=False, overwrite=False, merge=False):
         self.copy_buffer = tuple(copy_buffer)
         self.do_cut = do_cut
         self.original_copy_buffer = copy_buffer
         self.original_path = self.fm.thistab.path
         self.overwrite = overwrite
+        self.merge = merge
         self.percent = 0
         if self.copy_buffer:
             self.one_file = self.copy_buffer[0]
@@ -94,7 +95,8 @@ class CopyLoader(Loadable, FileManagerAware):
                             self.fm.tags.dump()
                     for _ in shutil_g.move(src=f.path,
                             dst=self.original_path,
-                            overwrite=self.overwrite):
+                            overwrite=self.overwrite,
+                            merge=self.merge):
                         self.percent += bar_tick
                         yield
             else:
@@ -107,13 +109,15 @@ class CopyLoader(Loadable, FileManagerAware):
                         for _ in shutil_g.copytree(src=f.path,
                                 dst=os.path.join(self.original_path, f.basename),
                                 symlinks=True,
-                                overwrite=self.overwrite):
+                                overwrite=self.overwrite,
+                                merge=self.merge):
                             self.percent += bar_tick
                             yield
                     else:
                         for _ in shutil_g.copy2(f.path, self.original_path,
                                 symlinks=True,
-                                overwrite=self.overwrite):
+                                overwrite=self.overwrite,
+                                merge=self.merge):
                             self.percent += bar_tick
                             yield
             cwd = self.fm.get_directory(self.original_path)


### PR DESCRIPTION
I added the merge command for pasting files as was requested here: https://github.com/hut/ranger/issues/142. If used with the cut command files that can be merged will be, then the source directory of the cut will be deleted.

I did at one point set the merge command, when cutting, to merge all possible files and then only delete files from the source directory that were merged but I felt that was redundant as it is very similar to just copying and merging so I reverted it.

I still have all the code if you would prefer the second method for cutting and merging.