### PR TITLE
allow ranger to be sourced (". ranger") without being installed in PATH

### DIFF
--- a/ranger.py
+++ b/ranger.py
@@ -10,7 +10,7 @@
 # The other arguments are passed to ranger.
 """":
 tempfile="$(mktemp)"
-ranger="${1:-ranger}"
+ranger="${1:-$0}"
 test -z "$1" || shift
 "$ranger" --choosedir="$tempfile" "${@:-$(pwd)}"
 returnvalue=$?


### PR DESCRIPTION
It makes a difference if the user wants to clone the ranger repository
and start ranger using the full path to "ranger.py" without installing
it anywhere.

Previously it was possible to pass the path to ranger in the next
argument but it is unnecessary since we already have the path of the
currently executed script (unless the user wants to override it, then it
is still possible).