### PR TITLE
Fix mktemp invocation to work on Mac OS X and Linux

### DIFF
--- a/examples/bash_automatic_cd.sh
+++ b/examples/bash_automatic_cd.sh
@@ -8,7 +8,7 @@
 # original directory.
 
 function ranger-cd {
-    tempfile="$(mktemp)"
+    tempfile="$(mktemp -t tmp.XXXXXX)"
     /usr/bin/ranger --choosedir="$tempfile" "${@:-$(pwd)}"
     test -f "$tempfile" &&
     if [ "$(cat -- "$tempfile")" != "$(echo -n `pwd`)" ]; then

--- a/ranger.py
+++ b/ranger.py
@@ -9,7 +9,7 @@
 # default is simply "ranger". (Not this file itself!)
 # The other arguments are passed to ranger.
 """":
-tempfile="$(mktemp)"
+tempfile="$(mktemp -t tmp.XXXXXX)"
 ranger="${1:-ranger}"
 test -z "$1" || shift
 "$ranger" --choosedir="$tempfile" "${@:-$(pwd)}"


### PR DESCRIPTION
mktemp on Mac OS X (and probably all BSDs) just returns an error when
invoked without any arguments.  The -t option used in this change is
interpreted differently on Mac OS X and Linux, and is deprecated on
Linux, but this invocation works as expected on both.

See discussion at https://unix.stackexchange.com/questions/30091
Another alternative would be to use Python's tempfile module:
https://docs.python.org/2/library/tempfile.html