### PR TITLE
put the previewed image in right place and clean image(only w3mimgdisplay)

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -77,7 +77,7 @@ class W3MImageDisplayer(ImageDisplayer):
         cmd = "6;{x};{y};{w};{h}\n4;\n3;\n".format(
                 x = int((start_x - 0.2) * fontw),
                 y = int((start_y + 0.6) * fonth),
-                w = int((width + 0.4)* fontw),
+                w = int((width + 0.4) * fontw),
                 h = int((height - 0.6) * fonth))
 
         self.process.stdin.write(cmd)

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -76,13 +76,10 @@ class W3MImageDisplayer(ImageDisplayer):
 
         cmd = "6;{x};{y};{w};{h}\n4;\n3;\n".format(
                 x = int((start_x - 0.2) * fontw),
-                # (for tmux top status line)
-                # y = int((start_y + 0.6) * fonth),
-                y = int((start_y - 0.4) * fonth),
+                y = start_y * fonth,
+                # y = int((start_y + 1) * fonth), # (for tmux top status bar)
                 w = int((width + 0.4) * fontw),
-                # (for tmux top status line)
-                # h = int((height - 0.2) * fonth) + 1)
-                h = int((height + 0.6) * fonth) + 1)
+                h = height * fonth + 1)
 
         self.process.stdin.write(cmd)
         self.process.stdin.flush()
@@ -99,9 +96,7 @@ class W3MImageDisplayer(ImageDisplayer):
             raise ImgDisplayUnsupportedException()
 
         max_width_pixels = max_width * fontw
-        # (for tmux top status line)
-        # max_height_pixels = int((max_height - 0.5) * fonth + 1)
-        max_height_pixels = int((max_height + 0.5) * fonth) + 1
+        max_height_pixels = max_height * fonth - 2
 
         # get image size
         cmd = "5;{}\n".format(path)
@@ -126,9 +121,8 @@ class W3MImageDisplayer(ImageDisplayer):
 
         return "0;1;{x};{y};{w};{h};;;;;{filename}\n4;\n3;\n".format(
                 x = int((start_x - 0.2) * fontw),
-                # (for tmux top status line)
-                # y = int((start_y + 0.6) * fonth),
-                y = int((start_y - 0.4) * fonth),
+                y = start_y * fonth,
+                # y = (start_y + 1) * fonth, # (for tmux top status bar)
                 w = width,
                 h = height,
                 filename = path)

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -75,10 +75,10 @@ class W3MImageDisplayer(ImageDisplayer):
         fontw, fonth = _get_font_dimensions()
 
         cmd = "6;{x};{y};{w};{h}\n4;\n3;\n".format(
-                x = start_x * fontw,
-                y = start_y * fonth,
-                w = (width + 1) * fontw,
-                h = height * fonth)
+                x = int((start_x - 0.2) * fontw),
+                y = int((start_y + 0.6) * fonth),
+                w = int((width + 0.4)* fontw),
+                h = int((height - 0.6) * fonth))
 
         self.process.stdin.write(cmd)
         self.process.stdin.flush()
@@ -95,7 +95,7 @@ class W3MImageDisplayer(ImageDisplayer):
             raise ImgDisplayUnsupportedException()
 
         max_width_pixels = max_width * fontw
-        max_height_pixels = max_height * fonth
+        max_height_pixels = (max_height - 1) * fonth
 
         # get image size
         cmd = "5;{}\n".format(path)
@@ -119,8 +119,8 @@ class W3MImageDisplayer(ImageDisplayer):
             height = max_height_pixels
 
         return "0;1;{x};{y};{w};{h};;;;;{filename}\n4;\n3;\n".format(
-                x = start_x * fontw,
-                y = start_y * fonth,
+                x = int((start_x - 0.2) * fontw),
+                y = int((start_y + 0.6) * fonth),
                 w = width,
                 h = height,
                 filename = path)

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -76,9 +76,13 @@ class W3MImageDisplayer(ImageDisplayer):
 
         cmd = "6;{x};{y};{w};{h}\n4;\n3;\n".format(
                 x = int((start_x - 0.2) * fontw),
-                y = int((start_y + 0.6) * fonth),
+                # (for tmux top status line)
+                # y = int((start_y + 0.6) * fonth),
+                y = int((start_y - 0.4) * fonth),
                 w = int((width + 0.4) * fontw),
-                h = int((height - 0.6) * fonth))
+                # (for tmux top status line)
+                # h = int((height - 0.2) * fonth) + 1)
+                h = int((height + 0.6) * fonth) + 1)
 
         self.process.stdin.write(cmd)
         self.process.stdin.flush()
@@ -95,7 +99,9 @@ class W3MImageDisplayer(ImageDisplayer):
             raise ImgDisplayUnsupportedException()
 
         max_width_pixels = max_width * fontw
-        max_height_pixels = (max_height - 1) * fonth
+        # (for tmux top status line)
+        # max_height_pixels = int((max_height - 0.5) * fonth + 1)
+        max_height_pixels = int((max_height + 0.5) * fonth) + 1
 
         # get image size
         cmd = "5;{}\n".format(path)
@@ -120,7 +126,9 @@ class W3MImageDisplayer(ImageDisplayer):
 
         return "0;1;{x};{y};{w};{h};;;;;{filename}\n4;\n3;\n".format(
                 x = int((start_x - 0.2) * fontw),
-                y = int((start_y + 0.6) * fonth),
+                # (for tmux top status line)
+                # y = int((start_y + 0.6) * fonth),
+                y = int((start_y - 0.4) * fonth),
                 w = width,
                 h = height,
                 filename = path)

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -80,6 +80,7 @@ class W3MImageDisplayer(ImageDisplayer):
                 # y = int((start_y + 1) * fonth), # (for tmux top status bar)
                 w = int((width + 0.4) * fontw),
                 h = height * fonth + 1)
+                # h = (height - 1) * fonth + 1) # (for tmux top status bar)
 
         self.process.stdin.write(cmd)
         self.process.stdin.flush()
@@ -97,6 +98,8 @@ class W3MImageDisplayer(ImageDisplayer):
 
         max_width_pixels = max_width * fontw
         max_height_pixels = max_height * fonth - 2
+        # (for tmux top status bar)
+        # max_height_pixels = (max_height - 1) * fonth - 2
 
         # get image size
         cmd = "5;{}\n".format(path)


### PR DESCRIPTION
This small changes make the previewed image to put in right place and properly clean the image properly.

Before:

(with border)
![before_with_border](https://cloud.githubusercontent.com/assets/8816330/8270728/c2da13ee-182a-11e5-98f2-c4472405fe54.jpg)

(without border)
![before_without_border](https://cloud.githubusercontent.com/assets/8816330/8270730/c7c6e6e8-182a-11e5-80ce-952600ee8ae1.jpg)

After:

(with border)
![after_with_border](https://cloud.githubusercontent.com/assets/8816330/8270731/ce18c912-182a-11e5-8669-b61f6e6510ba.jpg)

(without border)
![after_without_border](https://cloud.githubusercontent.com/assets/8816330/8270733/d3973702-182a-11e5-9feb-c0e2e204e743.jpg)

