### PR TITLE
Use setuptools if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.egg-info
 *.pyc
 *.pyo
 stuff/*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,12 @@
 # This file is part of ranger, the console file manager.
 # License: GNU GPL version 3, see the file "AUTHORS" for details.
 
-import distutils.core
+# Setuptools is superior but not available in the stdlib
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 import os.path
 import ranger
 
@@ -11,7 +16,7 @@ def _findall(directory):
             if os.path.isfile(os.path.join(directory, f))]
 
 if __name__ == '__main__':
-    distutils.core.setup(
+    setup(
         name='ranger',
         description='Vim-like file manager',
         long_description=ranger.__doc__,


### PR DESCRIPTION
The main reason for this is the presence of `develop` command in setuptools.

So by running `sudo python setup.py develop` - ranger gets installed, but you can easily make changes to the code and won't have to reinstall it.

You can read more about it here:
http://pythonhosted.org//setuptools/setuptools.html#development-mode

It basically links an egg, so I had to add an appropriate line to .gitignore as well.