### PR TITLE
preserve permissions when updating bookmarks. Fix for #59

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -156,6 +156,12 @@ class Bookmarks(object):
                         pass
 
             f.close()
+            old_perms = os.stat(self.path)
+            try:
+                os.chown(self.path+".new", old_perms.st_uid, old_perms.st_gid)
+                os.chmod(self.path+".new", old_perms.st_mode)
+            except OSError:
+                pass
             os.rename(self.path+".new", self.path)
         self._update_mtime()
 


### PR DESCRIPTION
Proposed fix for the (non-)bug #59, where the owner of the bookmarks file is changed to root when running ranger as root but with a user's environment. This could be called user error, but this patch will hopefully prevent further confusion such as #267. 

The try-except statement catches the (weird) case where the file is already owned by another user. 

Should this also be applied to other files managed by ranger?