### PR TITLE
Use scope.sh for all the previews

### DIFF
--- a/ranger/container/file.py
+++ b/ranger/container/file.py
@@ -76,8 +76,6 @@ class File(FileSystemObject):
         if self.fm.settings.preview_script and \
                 self.fm.settings.use_preview_script:
             return True
-        if self.image and self.fm.settings.preview_images:
-            return True
         if self.container:
             return False
         if PREVIEW_WHITELIST.search(self.basename):

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -17,12 +17,14 @@
 # 4    | fix height | success. Don't reload when height changes
 # 5    | fix both   | success. Don't ever reload
 # 6    | image      | success. display the image $cached points to as an image preview
+# 7    | image      | success. display the file directly as an image
 
 # Meaningful aliases for arguments:
-path="$1"    # Full path of the selected file
-width="$2"   # Width of the preview pane (number of fitting characters)
-height="$3"  # Height of the preview pane (number of fitting characters)
-cached="$4"  # Path that should be used to cache image previews
+path="$1"            # Full path of the selected file
+width="$2"           # Width of the preview pane (number of fitting characters)
+height="$3"          # Height of the preview pane (number of fitting characters)
+cached="$4"          # Path that should be used to cache image previews
+preview_images="$5"  # "True" if image previews are enabled, "False" otherwise.
 
 maxln=200    # Stop after $maxln lines.  Can be used like ls | head -n $maxln
 
@@ -43,6 +45,23 @@ trim() { head -n "$maxln"; }
 
 # wraps highlight to treat exit code 141 (killed by SIGPIPE) as success
 highlight() { command highlight "$@"; test $? = 0 -o $? = 141; }
+
+# Image previews, if enabled in ranger.
+if [ "$preview_images" = "True" ]; then
+    case "$mimetype" in
+        # Image previews for SVG files, disabled by default.
+        ###image/svg+xml)
+        ###   convert "$path" "$cached" && exit 6 || exit 1;;
+        # Image previews for image files. w3mimgdisplay will be called for all
+        # image files (unless overriden as above), but might fail for
+        # unsupported types.
+        image/*)
+            exit 7;;
+        # Image preview for video, disabled by default.:
+        ###video/*)
+        ###    ffmpegthumbnailer -i "$path" -o "$cached" -s 0 && exit 6 || exit 1;;
+    esac
+fi
 
 case "$extension" in
     # Archive extensions:
@@ -76,9 +95,6 @@ case "$mimetype" in
     # Ascii-previews of images:
     image/*)
         img2txt --gamma=0.6 --width="$width" "$path" && exit 4 || exit 1;;
-    # Image preview for videos, disabled by default:
-    # video/*)
-    #     ffmpegthumbnailer -i "$path" -o "$cached" -s 0 && exit 6 || exit 1;;
     # Display information about media files:
     video/* | audio/*)
         exiftool "$path" && exit 5

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -180,19 +180,15 @@ class BrowserColumn(Pager):
             Pager.close(self)
             return
 
-        if self.fm.settings.preview_images and self.target.image:
-            self.set_image(self.target.realpath)
-            Pager.draw(self)
+        f = self.target.get_preview_source(self.wid, self.hei)
+        if f is None:
+            Pager.close(self)
         else:
-            f = self.target.get_preview_source(self.wid, self.hei)
-            if f is None:
-                Pager.close(self)
+            if self.target.is_image_preview():
+                self.set_image(f)
             else:
-                if self.target.is_image_preview():
-                    self.set_image(f)
-                else:
-                    self.set_source(f)
-                Pager.draw(self)
+                self.set_source(f)
+            Pager.draw(self)
 
     def _draw_directory(self):
         """Draw the contents of a directory"""

--- a/ranger/gui/widgets/browserview.py
+++ b/ranger/gui/widgets/browserview.py
@@ -258,9 +258,7 @@ class BrowserView(Widget, DisplayableContainer):
         result = not self.columns[-1].has_preview()
         target = self.columns[-1].target
         if not result and target and target.is_file:
-            if target.image and self.fm.settings.preview_images:
-                result = False  # don't collapse when drawing images
-            elif self.fm.settings.preview_script and \
+            if self.fm.settings.preview_script and \
                     self.fm.settings.use_preview_script:
                 try:
                     result = not self.fm.previews[target.realpath]['foundpreview']
@@ -355,8 +353,7 @@ class BrowserView(Widget, DisplayableContainer):
             self.columns[-1].visible = True
 
         if self.preview and self.is_collapsed != self._collapse():
-            if (self.fm.settings.preview_images and
-                self.fm.settings.preview_files):
+            if self.fm.settings.preview_files:
                 # force clearing the image when resizing preview column
                 self.columns[-1].clear_image(force=True)
             self.resize(self.y, self.x, self.hei, self.wid)


### PR DESCRIPTION
… instead of calling w3mimgdisplay for (potentially non-supported, e.g.
SVG files) images, which also has the side effect of making custom
previews for images impossible.

This patch also handles #263 using solution 3, in order not to break
backward compatibility:

> **Solution 3:** Add an another variable to indicate whether an image
> should be generated and ignore the image if it still is created. It would
> work like the previous solution but would not break the existing configs.

scope.sh has also been slightly refactored to take into account this
change.

Should also take care of #371.

---

````
One Scope to rule them all, One Scope to find them,
One Scope to bring them all and in the terminal preview them
In the Land of Ranger where the Data lies.
````
