### PR TITLE
Fix the doc extraction for "dump_commands" and add some new documentation

### DIFF
--- a/ranger/api/commands.py
+++ b/ranger/api/commands.py
@@ -47,7 +47,7 @@ class CommandContainer(object):
                 continue
             attribute = getattr(obj, attribute_name)
             if hasattr(attribute, '__call__'):
-                cmd = type(attribute_name, (FunctionCommand, ), dict())
+                cmd = type(attribute_name, (FunctionCommand, ), dict(__doc__=attribute.__doc__))
                 cmd._based_function = attribute
                 cmd._function_name = attribute.__name__
                 cmd._object_name = obj.__class__.__name__

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1113,8 +1113,10 @@ class Actions(FileManagerAware, SettingsAware):
         for cmd_name in sorted(self.commands.commands):
             cmd = self.commands.commands[cmd_name]
             if hasattr(cmd, '__doc__') and cmd.__doc__:
-                write(cleandoc(cmd.__doc__))
-                write("\n\n" + "-" * 60 + "\n")
+                doc = cleandoc(cmd.__doc__)
+                if doc[0] == ':':
+                    write(doc)
+                    write("\n\n" + "-" * 60 + "\n")
             else:
                 undocumented.append(cmd)
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -41,11 +41,17 @@ class Actions(FileManagerAware, SettingsAware):
     # --------------------------
 
     def exit(self):
-        """Exit the program"""
+        """:exit
+
+        Exit the program.
+        """
         raise SystemExit()
 
     def reset(self):
-        """Reset the filemanager, clearing the directory buffer"""
+        """:reset
+
+        Reset the filemanager, clearing the directory buffer.
+        """
         old_path = self.thisdir.path
         self.previews = {}
         self.garbage_collect(-1)
@@ -55,6 +61,10 @@ class Actions(FileManagerAware, SettingsAware):
             self.metadata.reset()
 
     def change_mode(self, mode):
+        """:change_mode <mode>
+
+        Change mode to "visual" (selection) or "normal" mode.
+        """
         if mode == self.mode:
             return
         if mode == 'visual':
@@ -103,6 +113,10 @@ class Actions(FileManagerAware, SettingsAware):
         raise ValueError("Invalid value `%s' for option `%s'!" % (name, value))
 
     def toggle_visual_mode(self, reverse=False, narg=None):
+        """:toggle_visual_mode
+
+        Toggle the visual mode (see :change_mode).
+        """
         if self.mode == 'normal':
             self._visual_reverse = reverse
             if narg != None:
@@ -112,6 +126,10 @@ class Actions(FileManagerAware, SettingsAware):
             self.change_mode('normal')
 
     def reload_cwd(self):
+        """:reload_cwd
+
+        Reload the current working directory.
+        """
         try:
             cwd = self.thisdir
         except:
@@ -120,6 +138,10 @@ class Actions(FileManagerAware, SettingsAware):
         cwd.load_content()
 
     def notify(self, text, duration=4, bad=False):
+        """:notify <text>
+
+        Display the text in the statusbar.
+        """
         if isinstance(text, Exception):
             if ranger.arg.debug:
                 raise
@@ -135,6 +157,10 @@ class Actions(FileManagerAware, SettingsAware):
             print(text)
 
     def abort(self):
+        """:abort
+
+        Empty the first queued action.
+        """
         try:
             item = self.loader.queue[0]
         except:
@@ -150,16 +176,25 @@ class Actions(FileManagerAware, SettingsAware):
         self.ui.redraw_main_column()
 
     def redraw_window(self):
-        """Redraw the window"""
+        """:redraw
+
+        Redraw the window.
+        """
         self.ui.redraw_window()
 
     def open_console(self, string='', prompt=None, position=None):
-        """Open the console"""
+        """:open_console [string]
+
+        Open the console.
+        """
         self.change_mode('normal')
         self.ui.open_console(string, prompt=prompt, position=position)
 
     def execute_console(self, string='', wildcards=[], quantifier=None):
-        """Execute a command for the console"""
+        """:execute_console [string]
+
+        Execute a command for the console
+        """
         command_name = string.lstrip().split()[0]
         cmd_class = self.commands.get_command(command_name, abbrev=False)
         if cmd_class is None:
@@ -291,6 +326,10 @@ class Actions(FileManagerAware, SettingsAware):
         return macros
 
     def source(self, filename):
+        """:source <filename>
+
+        Load a config file.
+        """
         filename = os.path.expanduser(filename)
         for line in open(filename, 'r'):
             line = line.lstrip().rstrip("\r\n")
@@ -538,12 +577,18 @@ class Actions(FileManagerAware, SettingsAware):
         self.execute_file(file, label='editor')
 
     def toggle_option(self, string):
-        """Toggle a boolean option named <string>"""
+        """:toggle_option <string>
+
+        Toggle a boolean option named <string>.
+        """
         if isinstance(self.settings[string], bool):
             self.settings[string] ^= True
 
     def set_option(self, optname, value):
-        """Set the value of an option named <optname>"""
+        """:set_option <optname>
+
+        Set the value of an option named <optname>.
+        """
         self.settings[optname] = value
 
     def sort(self, func=None, reverse=None):
@@ -680,6 +725,10 @@ class Actions(FileManagerAware, SettingsAware):
     # file is important to you in any context.
 
     def tag_toggle(self, paths=None, value=None, movedown=None, tag=None):
+        """:tag_toggle <character>
+
+        Toggle a tag <character>.
+        """
         if not self.tags:
             return
         if paths is None:
@@ -1146,12 +1195,20 @@ class Actions(FileManagerAware, SettingsAware):
     # --------------------------
 
     def uncut(self):
+        """:uncut
+
+        Empty the copy buffer.
+        """
         self.copy_buffer = set()
         self.do_cut = False
         self.ui.browser.main_column.request_redraw()
 
     def copy(self, mode='set', narg=None, dirarg=None):
-        """Copy the selected items.  Modes are: 'set', 'add', 'remove'."""
+        """:copy [mode=set]
+
+        Copy the selected items.
+        Modes are: 'set', 'add', 'remove'.
+        """
         assert mode in ('set', 'add', 'remove')
         cwd = self.thisdir
         if not narg and not dirarg:
@@ -1178,6 +1235,11 @@ class Actions(FileManagerAware, SettingsAware):
         self.ui.browser.main_column.request_redraw()
 
     def cut(self, mode='set', narg=None, dirarg=None):
+        """:cut [mode=set]
+
+        Cut the selected items.
+        Modes are: 'set, 'add, 'remove.
+        """
         self.copy(mode=mode, narg=narg, dirarg=dirarg)
         self.do_cut = True
         self.ui.browser.main_column.request_redraw()
@@ -1226,7 +1288,10 @@ class Actions(FileManagerAware, SettingsAware):
                     next_available_filename(target_path))
 
     def paste(self, overwrite=False, append=False):
-        """Paste the selected items into the current directory"""
+        """:paste
+
+        Paste the selected items into the current directory.
+        """
         loadable = CopyLoader(self.copy_buffer, self.do_cut, overwrite)
         self.loader.add(loadable, append=append)
         self.do_cut = False


### PR DESCRIPTION
I've fixed the handling of the methods of the `Actions` class in the `dump_commands` function. Previously their docstrings were completely ignored. The new behavior is described in the commit message of 45ee436 and is applied to all the commands, not only the `Actions` class methods.

Additionally I've added the documentation to some of these methods.