### PR TITLE
scope.sh: Support unicode extensions

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -30,7 +30,7 @@ maxln=200    # Stop after $maxln lines.  Can be used like ls | head -n $maxln
 
 # Find out something about the file:
 mimetype=$(file --mime-type -Lb "$path")
-extension=$(/bin/echo "${path##*.}" | tr "[:upper:]" "[:lower:]")
+extension=$(/bin/echo "${path##*.}" | awk '{print tolower($0)}')
 
 # Functions:
 # runs a command and saves its output into $output.  Useful if you need


### PR DESCRIPTION
Most (all?) `tr` implementations do not support unicode.
Use `awk` instead for turning extensions to lowercase.