### PR TITLE
Allow the execution of the executable binary files via rifle

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -103,6 +103,7 @@ ext rb  = ruby -- "$1"
 ext js  = node -- "$1"
 ext sh  = sh -- "$1"
 ext php = php -- "$1"
+mime application/x-executable = "$1"
 
 #--------------------------------------------
 # Audio without X


### PR DESCRIPTION
It shouldn't be a security issue because the user still needs to enable the executable bit of the binary.