### PR TITLE
Fix the "X" rifle specifier for Mac OS X

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -231,7 +231,7 @@ class Rifle(object):
             self._app_flags = argument
             return True
         elif function == 'X':
-            return 'DISPLAY' in os.environ
+            return sys.platform == 'darwin' or 'DISPLAY' in os.environ
         elif function == 'env':
             return bool(os.environ.get(argument))
         elif function == 'else':


### PR DESCRIPTION
On Mac OS X the `$DISPLAY` environmental variable is never set. Checking for it to check if there is a graphical environment available will not work. I think it can be safely assumed that Mac OS X is always running with GUI.

Calling it "X" is a bit of a misnomer considering Mac OS X does not use X11, but I think it still conveys the meaning well. Or we could retcon the meaning of "X" on Macs to "Mac OS **X**". ;)