### PR TITLE
Fix for issue #332. Broken file shortening.

### DIFF
--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -25,20 +25,28 @@ class CursesShortcuts(SettingsAware):
     """
 
     def addstr(self, *args):
+        y, x = self.win.getyx()
+
         try:
             self.win.addstr(*args)
         except:
             if len(args) > 1:
+                self.win.move(y, x)
+
                 try:
                     self.win.addstr(*_fix_surrogates(args))
                 except:
                     pass
 
     def addnstr(self, *args):
+        y, x = self.win.getyx()
+
         try:
             self.win.addnstr(*args)
         except:
             if len(args) > 2:
+                self.win.move(y, x)
+
                 try:
                     self.win.addnstr(*_fix_surrogates(args))
                 except:


### PR DESCRIPTION
The filename on the second to last line of the screen is now properly
shortened.