### PR TITLE
Added %p macro for full paths of selected files.

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -201,11 +201,12 @@ Macros can be used in commands to abbreviate things.
 
  %f   the highlighted file
  %d   the path of the current directory
- %s   the selected files in the current directory.
+ %s   the selected files in the current directory
  %t   all tagged files in the current directory
  %c   the full paths of the currently copied/cut files
+ %p   the full paths of selected files
 
-The macros %f, %d and %s also have upper case variants, %F, %D and %S,
+The macros %f, %d, %p, and %s also have upper case variants, %F, %D, %P, and %S,
 which refer to the next tab.  To refer to specific tabs, add a number in
 between.  (%7s = selection of the seventh tab.)
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -253,8 +253,10 @@ class Actions(FileManagerAware, SettingsAware):
             macros['f'] = MACRO_FAIL
 
         if self.fm.thistab.get_selection:
+            macros['p'] = [os.path.join(self.fm.thisdir.path, fl.relative_path) for fl in self.fm.thistab.get_selection()]
             macros['s'] = [fl.relative_path for fl in self.fm.thistab.get_selection()]
         else:
+            macros['p'] = MACRO_FAIL
             macros['s'] = MACRO_FAIL
 
         if self.fm.copy_buffer:
@@ -273,7 +275,7 @@ class Actions(FileManagerAware, SettingsAware):
         else:
             macros['d'] = '.'
 
-        # define d/f/s macros for each tab
+        # define d/f/p/s macros for each tab
         for i in range(1,10):
             try:
                 tab = self.fm.tabs[i]
@@ -285,15 +287,17 @@ class Actions(FileManagerAware, SettingsAware):
             i = str(i)
             macros[i + 'd'] = tabdir.path
             if tabdir.get_selection():
+                macros[i + 'p'] = [os.path.join(tabdir.path, fl.relative_path) for fl in tabdir.get_selection()]
                 macros[i + 's'] = [fl.path for fl in tabdir.get_selection()]
             else:
+                macros[i + 'p'] = MACRO_FAIL
                 macros[i + 's'] = MACRO_FAIL
             if tabdir.pointed_obj:
                 macros[i + 'f'] = tabdir.pointed_obj.path
             else:
                 macros[i + 'f'] = MACRO_FAIL
 
-        # define D/F/S for the next tab
+        # define D/F/P/S for the next tab
         found_current_tab = False
         next_tab = None
         first_tab = None
@@ -316,8 +320,10 @@ class Actions(FileManagerAware, SettingsAware):
             else:
                 macros['F'] = MACRO_FAIL
             if next_tab_dir.get_selection():
+                macros['P'] = [os.path.join(next_tab.path, fl.path) for fl in next_tab.get_selection()]
                 macros['S'] = [fl.path for fl in next_tab.get_selection()]
             else:
+                macros['P'] = MACRO_FAIL
                 macros['S'] = MACRO_FAIL
         else:
             macros['D'] = MACRO_FAIL


### PR DESCRIPTION
Many shell utilities expect full paths.  The %s macro provides basenames in most usage cases, so I added %p/%P/%#p for explicitly retrieving full paths.