### PR TITLE
Fringe Cases When Matching File Extensions

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -880,6 +880,7 @@ ranger.  For your convenience, this is a list of the "public" commands including
  flat level
  grep pattern
  help
+ jump [wrap]
  linemode linemodename
  load_copy_buffer
  map key command
@@ -1064,6 +1065,11 @@ Looks for a string in all marked files or directories.
 =item help
 
 Provides a quick way to view ranger documentations.
+
+=item jump I<wrap>
+
+Selects the first file, if the current selection is a directory.  Selects the
+first directory, if the current selection is a file.
 
 =item linemode I<linemodename>
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -537,6 +537,33 @@ class delete(Command):
             self.fm.delete()
 
 
+class jump(Command):
+    """:jump [<wrap>]
+
+    Selects first file if current selection is a directory.
+    Selects first directory if current selection is a file.
+    """
+    def execute(self, wrap = True):
+        cf = self.fm.thisfile
+        passed_cf = False
+        for fileobj in self.fm.thisdir.files:
+            if fileobj.path == cf.path:
+                passed_cf = True
+                continue
+            elif passed_cf and (fileobj.is_directory if not cf.is_directory else not fileobj.is_directory):
+                self.fm.select_file(fileobj.path)
+                return
+        # exhausted every path
+        if wrap:
+            for fileobj in self.fm.thisdir.files:
+                if fileobj.path == cf.path:
+                    # sorry, no hit
+                    return
+                elif fileobj.is_directory if not cf.is_directory else not fileobj.is_directory:
+                    self.fm.select_file(fileobj.path)
+                    return
+
+
 class mark_tag(Command):
     """:mark_tag [<tags>]
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -309,6 +309,7 @@ map L     history_go 1
 map ]     move_parent 1
 map [     move_parent -1
 map }     traverse
+map )     jump
 
 map gh cd ~
 map ge cd /etc

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -194,9 +194,11 @@ class Rifle(object):
         function = rule[0]
         argument = rule[1] if len(rule) > 1 else ''
 
-        if function == 'ext':
-            extension = os.path.basename(files[0]).rsplit('.', 1)[-1].lower()
-            return bool(re.search('^(' + argument + ')$', extension))
+        if function == 'ext' and os.path.isfile(files[0]):
+            partitions = os.path.basename(files[0]).rpartition('.')
+            if not partitions[0] and not partitions[1]:
+                return False
+            return bool(re.search('^(' + argument + ')$', partitions[2].lower()))
         elif function == 'name':
             return bool(re.search(argument, os.path.basename(files[0])))
         elif function == 'match':

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -194,9 +194,11 @@ class Rifle(object):
         function = rule[0]
         argument = rule[1] if len(rule) > 1 else ''
 
-        if function == 'ext':
-            extension = os.path.basename(files[0]).rsplit('.', 1)[-1].lower()
-            return bool(re.search('^(' + argument + ')$', extension))
+        if function == 'ext' and os.path.isfile(files[0]):
+            partitions = os.path.basename(files[0]).rpartition('.')
+            if not partitions[0]:
+                return False
+            return bool(re.search('^(' + argument + ')$', partitions[2].lower()))
         elif function == 'name':
             return bool(re.search(argument, os.path.basename(files[0])))
         elif function == 'match':

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -194,11 +194,9 @@ class Rifle(object):
         function = rule[0]
         argument = rule[1] if len(rule) > 1 else ''
 
-        if function == 'ext' and os.path.isfile(files[0]):
-            partitions = os.path.basename(files[0]).rpartition('.')
-            if not partitions[0] and not partitions[1]:
-                return False
-            return bool(re.search('^(' + argument + ')$', partitions[2].lower()))
+        if function == 'ext':
+            extension = os.path.basename(files[0]).rsplit('.', 1)[-1].lower()
+            return bool(re.search('^(' + argument + ')$', extension))
         elif function == 'name':
             return bool(re.search(argument, os.path.basename(files[0])))
         elif function == 'match':


### PR DESCRIPTION
The previous code allowed for non-extension cases to evaluate as file extensions.  Here are three examples:

/etc/modprobe.d directory opening as a D source code file
./jpg directory opening as JPEG file
~/.mkv text file opening as an MKV movie file

The new code only considers a file extension if it belongs to a file and has a file name preceding a period.