### PR TITLE
Rifle's ext condition now handles fringe cases.

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -194,9 +194,11 @@ class Rifle(object):
         function = rule[0]
         argument = rule[1] if len(rule) > 1 else ''
 
-        if function == 'ext':
-            extension = os.path.basename(files[0]).rsplit('.', 1)[-1].lower()
-            return bool(re.search('^(' + argument + ')$', extension))
+        if function == 'ext' and os.path.isfile(files[0]):
+            partitions = os.path.basename(files[0]).rpartition('.')
+            if not partitions[0]:
+                return False
+            return bool(re.search('^(' + argument + ')$', partitions[2].lower()))
         elif function == 'name':
             return bool(re.search(argument, os.path.basename(files[0])))
         elif function == 'match':


### PR DESCRIPTION
Previously, rifle would recognize certain non-extensions as file extensions.  Three examples:

/etc/modules.d directory opening as a D source code file
./jpg directory opening as JPEG file
~/.mkv text file opening as an MKV movie file

These modifications only evaluate a file extension if it is part of a file and has a file name before a period.