### PR TITLE
core.fm: Save the version of the copied configs

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -224,8 +224,8 @@ class FM(Actions, SignalDispatcher):
         try:
             with open(version_file_path, 'r') as version_file:
                 for line in version_file:
-                    config, _, version = line.strip().partition(": ")
-                    versions[config] = version
+                    config, _, version = line.partition(": ")
+                    versions[config.strip()] = version.strip()
         except IOError:
             pass
         return versions


### PR DESCRIPTION
This will allow to later check against the stored version upon upgrade to inform the user they may need to update their config. Like the recent issues with `scope.sh`. Even if we'll not automate it, it will be possible to ask the user for this info to help resolve the issues.

I've decided to use a plain-text format instead of using `repr` because the added complexity is negligible while the format being much more user friendly.