### PR TITLE
core.main: Log the fact of disabling the file previews for root

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -107,6 +107,7 @@ def main():
         if fm.username == 'root':
             fm.settings.preview_files = False
             fm.settings.use_preview_script = False
+            fm.log.append("Running as root, disabling the file previews.")
         if not arg.debug:
             from ranger.ext import curses_interrupt_handler
             curses_interrupt_handler.install_interrupt_handler()


### PR DESCRIPTION
It seems like a good idea to document somewhere the fact that the previews are disabled for root. This patch appends an information to the <kbd>W</kbd> log.