### PR TITLE
Make natural_sort's behaviour better defined

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -30,7 +30,7 @@ else:
     from string import maketrans
 _unsafe_chars = '\n' + ''.join(map(chr, range(32))) + ''.join(map(chr, range(128, 256)))
 _safe_string_table = maketrans(_unsafe_chars, '?' * len(_unsafe_chars))
-_extract_number_re = re.compile(r'(\d+)')
+_extract_number_re = re.compile(r'(\d+|\D)')
 
 def safe_path(path):
     return path.translate(_safe_string_table)
@@ -134,12 +134,12 @@ class FileSystemObject(FileManagerAware, SettingsAware):
 
     @lazy_property
     def basename_natural(self):
-        return [int(s) if s.isdigit() else s \
+        return [('0', int(s)) if s.isdigit() else (s, 0) \
                 for s in _extract_number_re.split(self.relative_path)]
 
     @lazy_property
     def basename_natural_lower(self):
-        return [int(s) if s.isdigit() else s \
+        return [('0', int(s)) if s.isdigit() else (s, 0) \
                 for s in _extract_number_re.split(self.relative_path_lower)]
 
     @lazy_property

--- a/tests/ranger/container/test_fsobject.py
+++ b/tests/ranger/container/test_fsobject.py
@@ -1,0 +1,38 @@
+import pytest
+import operator
+
+from ranger.container.fsobject import FileSystemObject
+
+
+class MockFM(object):
+    """Used to fullfill the dependency by FileSystemObject."""
+
+    default_linemodes = []
+
+
+def create_filesystem_object(path):
+    """Create a FileSystemObject without an fm object."""
+    fso = FileSystemObject.__new__(FileSystemObject)
+    fso.fm = MockFM()
+    fso.__init__(path)
+    return fso
+
+
+def test_basename_natural1():
+    """Test filenames without extensions."""
+    fsos = [create_filesystem_object(path)
+            for path in "hello", "hello1", "hello2"]
+    print("fsos", repr(fsos))
+    print("sorted(fsos)", repr(sorted(fsos[::-1])))
+    assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural")))
+    assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural_lower")))
+
+
+def test_basename_natural2():
+    """Test filenames with extensions."""
+    fsos = [create_filesystem_object(path)
+            for path in "hello", "hello.txt", "hello1.txt", "hello2.txt"]
+    print("fsos", repr(fsos))
+    print("sorted(fsos)", repr(sorted(fsos[::-1])))
+    assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural")))
+    assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural_lower")))

--- a/tests/ranger/container/test_fsobject.py
+++ b/tests/ranger/container/test_fsobject.py
@@ -22,8 +22,6 @@ def test_basename_natural1():
     """Test filenames without extensions."""
     fsos = [create_filesystem_object(path)
             for path in "hello", "hello1", "hello2"]
-    print("fsos", repr(fsos))
-    print("sorted(fsos)", repr(sorted(fsos[::-1])))
     assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural")))
     assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural_lower")))
 
@@ -32,7 +30,5 @@ def test_basename_natural2():
     """Test filenames with extensions."""
     fsos = [create_filesystem_object(path)
             for path in "hello", "hello.txt", "hello1.txt", "hello2.txt"]
-    print("fsos", repr(fsos))
-    print("sorted(fsos)", repr(sorted(fsos[::-1])))
     assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural")))
     assert(fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural_lower")))


### PR DESCRIPTION
The old version relied on comparing integers to strings which is not
supported in Python 3 anymore and not a good practice in general anyway.
It was also the case that 'hello2' was ordered before 'hello' instead of
after, which I found to be non-intuitive.