### PR TITLE
Add MtimeLinemode and SizeMtimeLinemode

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -79,7 +79,8 @@ class FileSystemObject(FileManagerAware, SettingsAware):
     _linemode = DEFAULT_LINEMODE
     linemode_dict = dict(
         (linemode.name, linemode()) for linemode in
-        [DefaultLinemode, TitleLinemode, PermissionsLinemode, FileInfoLinemode]
+        [DefaultLinemode, TitleLinemode, PermissionsLinemode, FileInfoLinemode,
+         MtimeLinemode, SizeMtimeLinemode]
     )
 
     def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -5,6 +5,8 @@
 
 import sys
 from abc import *
+from datetime import datetime
+from ranger.ext.human_readable import human_readable
 
 DEFAULT_LINEMODE = "filename"
 
@@ -102,3 +104,22 @@ class FileInfoLinemode(LinemodeBase):
             return fileinfo
         else:
             raise NotImplementedError
+
+class MtimeLinemode(LinemodeBase):
+    name = "mtime"
+
+    def filetitle(self, file, metadata):
+        return file.relative_path
+
+    def infostring(self, file, metadata):
+        return datetime.fromtimestamp(file.stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+
+class SizeMtimeLinemode(LinemodeBase):
+    name = "sizemtime"
+
+    def filetitle(self, file, metadata):
+        return file.relative_path
+
+    def infostring(self, file, metadata):
+        return "%s %s" % (human_readable(file.size),
+                          datetime.fromtimestamp(file.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))


### PR DESCRIPTION
Thanks to @Vifon for his help.  Fixes #520.  Conflicts with #521.

It might be worth considering making the `sizemtime` linemode the default, because it most closely resembles the output of `ls -l`.