### PR TITLE
Add __eq__, __neq__, and __hash__ to class File

### DIFF
--- a/ranger/container/file.py
+++ b/ranger/container/file.py
@@ -96,3 +96,12 @@ class File(FileSystemObject):
             return self.fm.previews[self.realpath]['imagepreview']
         except KeyError:
             return False
+
+    def __eq__(self, other):
+        return isinstance(other, File) and self.path == other.path
+
+    def __neq__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.path)


### PR DESCRIPTION
Adding or removing a file or directory in the current directory made ranger update itself, by creating new File objects. 

Lack of custom __eq__, __neq__, and __hash__ methods meant those new File objects would not be equal or even have the same hash as preexisting File objects with the same path. 

In the file actions.py, class Actions, method copy, the functions difference_update and symmetric_difference_update would give bad results because some of their parameters would contain preexisting File objects and some would contain new File objects.

These new methods test for equality, and perform hashing on the File object's path field, so preexisting and new File objects are equal/have the same hash as long as they have the same path.

Fix for issue #483.