### PR TITLE
`draw_progress_bar_in_statusbar' does not exist

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -710,8 +710,8 @@ Display tags in all columns?
 .IP "draw_borders [bool]" 4
 .IX Item "draw_borders [bool]"
 Draw borders around columns?
-.IP "draw_progress_bar_in_statusbar [bool]" 4
-.IX Item "draw_progress_bar_in_statusbar [bool]"
+.IP "draw_progress_bar_in_status_bar [bool]" 4
+.IX Item "draw_progress_bar_in_status_bar [bool]"
 Draw a progress bar in the status bar which displays the average state of all
 currently running tasks which support progress bars?
 .IP "flushinput [bool] <zi>" 4


### PR DESCRIPTION
A correction of a simple typo in one of the options described in the man page.  