### PR TITLE
2 small changes to loading plugins

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,6 +6,7 @@
 import os.path
 import sys
 import tempfile
+import importlib
 
 def main():
     """initialize objects and run the filemanager"""
@@ -301,7 +302,8 @@ def load_settings(fm, clean):
             ranger.fm = fm
             for plugin in sorted(plugins):
                 try:
-                    module = __import__('plugins', fromlist=[plugin])
+                    module = importlib.import_module('plugins.' + plugin)
+                    fm.commands.load_commands_from_module(module)
                     fm.log.append("Loaded plugin '%s'." % plugin)
                 except Exception as e:
                     fm.log.append("Error in plugin '%s'" % plugin)


### PR DESCRIPTION
1. Use importlib instead of __import__ because the later messes up the global namespace within the plugin.
2. Try to load commands from the plugin, because it is a huge pain to inject new commands from within the plugin itself. I am aware of the commands file, but sharing a command by telling someone to paste some code at the end of a file isn't particularly fun.